### PR TITLE
Add tag management and card–tag linking in repositories

### DIFF
--- a/lib/repository/flash_card_repository.dart
+++ b/lib/repository/flash_card_repository.dart
@@ -1,21 +1,65 @@
 import 'package:isar/isar.dart';
+
 import 'flashCard.dart';
 import 'isar_setup.dart';
 
 // タグ機能を管理するクラス
 class TagRepository {
-  // create a new card
-  Future<void> addTag(List tagDate) async{
-    // タグをDBに保存するメソッド
+  // タグを作成
+  Future<Tag> addTag({required String name, String? color}) async {
+    final newTag = Tag()
+      ..name = name
+      ..color = color;
+
+    await isar.writeTxn(() async {
+      await isar.tags.put(newTag);
+    });
+
+    return newTag;
   }
 
-  // get a all tags
-  
-  // update a tag
+  // すべてのタグを取得
+  Future<List<Tag>> getAllTags() async {
+    return isar.tags.where().sortByName().findAll();
+  }
 
-  // delete a tags
+  // idでタグを取得
+  Future<Tag?> getTagById(int id) async {
+    return isar.tags.get(id);
+  }
 
-  // delete a all tags
+  // 名前でタグを検索（部分一致）
+  Future<List<Tag>> searchTagsByName(String keyword) async {
+    return isar.tags.filter().nameContains(keyword, caseSensitive: false).findAll();
+  }
+
+  // タグを更新
+  Future<void> updateTag(Tag tag) async {
+    await isar.writeTxn(() async {
+      await isar.tags.put(tag);
+    });
+  }
+
+  // タグを削除（カードとのリンクも同時に解除）
+  Future<void> deleteTag(int id) async {
+    await isar.writeTxn(() async {
+      final tag = await isar.tags.get(id);
+      if (tag == null) {
+        return;
+      }
+
+      final linkedCards = await isar.flashCards.filter().tags((q) => q.idEqualTo(id)).findAll();
+      for (final card in linkedCards) {
+        await card.tags.load();
+        card.tags.removeWhere((linkedTag) => linkedTag.id == id);
+        await card.tags.save();
+      }
+
+      await isar.tags.delete(id);
+    });
+  }
+
+  // タグをすべて削除
   Future<void> deleteAllTags() async {
     await isar.writeTxn(() async {
       // .clearで全てのデータを削除する
@@ -24,10 +68,9 @@ class TagRepository {
   }
 }
 
-
 // フラッシュカードの処理を管理するclass
 class CardRepository {
-  // create a new card
+  // カードを作成
   Future<void> addCard(List cardData) async {
     final newCard =
         FlashCard()
@@ -38,6 +81,7 @@ class CardRepository {
           ..lastReviewedAt = null
           ..lastupdateTime = null
           ..isCorrect = null;
+
     // カスケード記法は記述の最後にコロンをつける -> これをつけないとエラーになる
     // 一つのオブジェクトに対して、連続でメソッドやプロパティを連続で指定できる記法のこと
     await isar.writeTxn(() async {
@@ -46,12 +90,59 @@ class CardRepository {
     });
   }
 
-  // get a all cards
+  // すべてのカードを取得
   Future<List<FlashCard>> getAllCards() async {
-    return await isar.flashCards.where().findAll();
+    return isar.flashCards.where().findAll();
   }
 
-  // update a card
+  // タグ付きのカードをすべて取得
+  Future<List<FlashCard>> getCardsByTagId(int tagId) async {
+    return isar.flashCards.filter().tags((q) => q.idEqualTo(tagId)).findAll();
+  }
+
+  // カードにタグを追加
+  Future<void> addTagToCard({required int cardId, required int tagId}) async {
+    await isar.writeTxn(() async {
+      final card = await isar.flashCards.get(cardId);
+      final tag = await isar.tags.get(tagId);
+      if (card == null || tag == null) {
+        return;
+      }
+
+      await card.tags.load();
+      if (!card.tags.any((existingTag) => existingTag.id == tagId)) {
+        card.tags.add(tag);
+        await card.tags.save();
+      }
+    });
+  }
+
+  // カードからタグを削除
+  Future<void> removeTagFromCard({required int cardId, required int tagId}) async {
+    await isar.writeTxn(() async {
+      final card = await isar.flashCards.get(cardId);
+      if (card == null) {
+        return;
+      }
+
+      await card.tags.load();
+      card.tags.removeWhere((tag) => tag.id == tagId);
+      await card.tags.save();
+    });
+  }
+
+  // カードに紐づくタグを取得
+  Future<List<Tag>> getTagsForCard(int cardId) async {
+    final card = await isar.flashCards.get(cardId);
+    if (card == null) {
+      return [];
+    }
+
+    await card.tags.load();
+    return card.tags.toList();
+  }
+
+  // カードを更新
   Future<void> updateCard(FlashCard flashCard) async {
     // DBに保存したデータを取り出す
     await isar.writeTxn(() async {
@@ -59,14 +150,14 @@ class CardRepository {
     });
   }
 
-  // delete a card
+  // カードを削除
   Future<void> deleteCard(int id) async {
     await isar.writeTxn(() async {
       await isar.flashCards.delete(id);
     });
   }
 
-  // delete a  all cards
+  // カードをすべて削除
   Future<void> deleteAllCards() async {
     await isar.writeTxn(() async {
       // .clearで全てのデータを削除する


### PR DESCRIPTION
### Motivation
- Provide a complete data-layer implementation for tag support so tags can be created, queried, updated, deleted, and associated with flash cards.
- Ensure tag deletion safely unlinks tags from any associated cards to keep the database consistent.

### Description
- Implemented `TagRepository` with `addTag`, `getAllTags`, `getTagById`, `searchTagsByName`, `updateTag`, `deleteTag` (which unlinks tags from linked flash cards), and `deleteAllTags` in `lib/repository/flash_card_repository.dart`.
- Added card-tag operations to `CardRepository`, including `getCardsByTagId`, `addTagToCard`, `removeTagFromCard`, and `getTagsForCard`, plus existing card CRUD remains intact.
- Used Isar link management APIs to load, add, remove, and save tag links on `FlashCard` objects to maintain referential integrity.
- No UI changes were introduced; all work is confined to repository/data-layer logic.

### Testing
- Attempted to run `dart format lib/repository/flash_card_repository.dart`, but the `dart` command was not available in this environment so formatting could not be verified.
- Attempted to run `flutter --version`, but the `flutter` command was not available in this environment so SDK checks could not be performed.
- No automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a49875e88328bd1be4341d7a2f8a)