### PR TITLE
Add tag creation/editing from card create/edit pages

### DIFF
--- a/lib/repository/flash_card_repository.dart
+++ b/lib/repository/flash_card_repository.dart
@@ -2,6 +2,20 @@ import 'package:isar/isar.dart';
 import 'flashCard.dart';
 import 'isar_setup.dart';
 
+class CardDraft {
+  final String question;
+  final String answer;
+  final String explanation;
+  final List<String> tagNames;
+
+  CardDraft({
+    required this.question,
+    required this.answer,
+    required this.explanation,
+    required this.tagNames,
+  });
+}
+
 // タグ機能を管理するクラス
 class TagRepository {
   // タグを作成
@@ -69,13 +83,45 @@ class TagRepository {
 
 // フラッシュカードの処理を管理するclass
 class CardRepository {
+  List<String> _normalizeTagNames(List<String> tagNames) {
+    final normalizedTagNames = <String>{};
+    for (final tagName in tagNames) {
+      final normalizedTagName = tagName.trim();
+      if (normalizedTagName.isEmpty) {
+        continue;
+      }
+      normalizedTagNames.add(normalizedTagName);
+    }
+    return normalizedTagNames.toList();
+  }
+
+  Future<List<Tag>> _resolveTags(List<String> tagNames) async {
+    final tags = <Tag>[];
+
+    for (final tagName in _normalizeTagNames(tagNames)) {
+      final existingTag = await isar.tags.filter().nameEqualTo(tagName).findFirst();
+      if (existingTag != null) {
+        tags.add(existingTag);
+        continue;
+      }
+
+      final newTag = Tag()
+        ..name = tagName
+        ..color = null;
+      await isar.tags.put(newTag);
+      tags.add(newTag);
+    }
+
+    return tags;
+  }
+
   // カードを作成
-  Future<void> addCard(List cardData) async {
+  Future<void> addCard(CardDraft cardData) async {
     final newCard =
         FlashCard()
-          ..question = cardData[0]
-          ..answer = cardData[1]
-          ..explanation = cardData[2]
+          ..question = cardData.question
+          ..answer = cardData.answer
+          ..explanation = cardData.explanation
           ..createTime = DateTime.now()
           ..lastReviewedAt = null
           ..lastupdateTime = null
@@ -86,6 +132,9 @@ class CardRepository {
     await isar.writeTxn(() async {
       // 引数cardDateから受けどったデータnewCardをDBに保存する
       await isar.flashCards.put(newCard);
+      final tags = await _resolveTags(cardData.tagNames);
+      newCard.tags.addAll(tags);
+      await newCard.tags.save();
     });
   }
 
@@ -146,6 +195,22 @@ class CardRepository {
     // DBに保存したデータを取り出す
     await isar.writeTxn(() async {
       await isar.flashCards.put(flashCard);
+    });
+  }
+
+  // カード更新時にタグを同期
+  Future<void> updateCardWithTags({
+    required FlashCard flashCard,
+    required List<String> tagNames,
+  }) async {
+    await isar.writeTxn(() async {
+      await isar.flashCards.put(flashCard);
+
+      final tags = await _resolveTags(tagNames);
+      await flashCard.tags.load();
+      flashCard.tags.clear();
+      flashCard.tags.addAll(tags);
+      await flashCard.tags.save();
     });
   }
 

--- a/lib/screens/create_page.dart
+++ b/lib/screens/create_page.dart
@@ -1,4 +1,5 @@
 import 'package:ankicards/service/gemini_api_service.dart';
+import 'package:ankicards/repository/flash_card_repository.dart';
 import 'package:ankicards/widget/buttonContainer.dart';
 import 'package:flutter/material.dart';
 
@@ -17,6 +18,7 @@ class _CreatePageState extends State<CreatePage> {
   final TextEditingController _controllerQ = TextEditingController();
   final TextEditingController _controllerA = TextEditingController();
   final TextEditingController _controllerE = TextEditingController();
+  final TextEditingController _controllerTags = TextEditingController();
 
   // メモリ開放 -> 通常宣言はしないがメモリリーク防止のため
   @override
@@ -25,6 +27,7 @@ class _CreatePageState extends State<CreatePage> {
     _controllerQ.dispose();
     _controllerA.dispose();
     _controllerE.dispose();
+    _controllerTags.dispose();
   }
 
   @override
@@ -78,6 +81,18 @@ class _CreatePageState extends State<CreatePage> {
               ),
             ),
             SizedBox(height: 20),
+            TextField(
+              autocorrect: true,
+              controller: _controllerTags,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(),
+                ),
+                hintText: "タグ（, 区切り）",
+              ),
+            ),
+            SizedBox(height: 20),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -93,8 +108,19 @@ class _CreatePageState extends State<CreatePage> {
                     final question = _controllerQ.text;
                     final answer = _controllerA.text;
                     final explanation = _controllerE.text;
+                    final tags =
+                        _controllerTags.text
+                            .split(',')
+                            .map((tag) => tag.trim())
+                            .where((tag) => tag.isNotEmpty)
+                            .toList();
 
-                    final newCard = [question, answer, explanation];
+                    final newCard = CardDraft(
+                      question: question,
+                      answer: answer,
+                      explanation: explanation,
+                      tagNames: tags,
+                    );
                     Navigator.pop(context, newCard);
                   },
                 ),

--- a/lib/screens/edit_page.dart
+++ b/lib/screens/edit_page.dart
@@ -1,6 +1,14 @@
 import 'package:ankicards/repository/flashCard.dart';
+import 'package:ankicards/repository/flash_card_repository.dart';
 import 'package:ankicards/widget/buttonContainer.dart';
 import 'package:flutter/material.dart';
+
+class EditCardResult {
+  final FlashCard card;
+  final List<String> tagNames;
+
+  EditCardResult({required this.card, required this.tagNames});
+}
 
 class EditPage extends StatefulWidget {
   final FlashCard card;
@@ -11,11 +19,14 @@ class EditPage extends StatefulWidget {
 }
 
 class _EditPageState extends State<EditPage> {
+  final CardRepository _cardRepository = CardRepository();
+
   // テキストコントローラーを設定
   // late -> lateを使うことで代入を後回しにすることができる
   late TextEditingController _controllerQ;
   late TextEditingController _controllerA;
   late TextEditingController _controllerE;
+  late TextEditingController _controllerTags;
 
   @override
   void initState() {
@@ -24,6 +35,18 @@ class _EditPageState extends State<EditPage> {
     _controllerQ = TextEditingController(text: widget.card.question);
     _controllerA = TextEditingController(text: widget.card.answer);
     _controllerE = TextEditingController(text: widget.card.explanation);
+    _controllerTags = TextEditingController();
+    _loadTags();
+  }
+
+  Future<void> _loadTags() async {
+    final tags = await _cardRepository.getTagsForCard(widget.card.id);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _controllerTags.text = tags.map((tag) => tag.name).join(', ');
+    });
   }
 
   @override
@@ -32,6 +55,7 @@ class _EditPageState extends State<EditPage> {
     _controllerQ.dispose();
     _controllerA.dispose();
     _controllerE.dispose();
+    _controllerTags.dispose();
     super.dispose();
   }
 
@@ -83,6 +107,18 @@ class _EditPageState extends State<EditPage> {
               controller: _controllerE,
             ),
             SizedBox(height: 20),
+            TextField(
+              autocorrect: true,
+              decoration: InputDecoration(
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(),
+                ),
+                border: OutlineInputBorder(),
+                hintText: 'タグ（, 区切り）',
+              ),
+              controller: _controllerTags,
+            ),
+            SizedBox(height: 20),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -100,8 +136,17 @@ class _EditPageState extends State<EditPage> {
                           ..answer = _controllerA.text
                           ..explanation = _controllerE.text
                           ..lastupdateTime = DateTime.now();
+                    final tagNames =
+                        _controllerTags.text
+                            .split(',')
+                            .map((tag) => tag.trim())
+                            .where((tag) => tag.isNotEmpty)
+                            .toList();
 
-                    Navigator.pop(context, updateCard);
+                    Navigator.pop(
+                      context,
+                      EditCardResult(card: updateCard, tagNames: tagNames),
+                    );
                   },
                 ),
                 SizedBox(width: 10),

--- a/lib/screens/list_page.dart
+++ b/lib/screens/list_page.dart
@@ -28,7 +28,7 @@ class _ListPageState extends State<ListPage> {
   }
 
   // カードの追加
-  Future<void> _addCard(List newCard) async {
+  Future<void> _addCard(CardDraft newCard) async {
     await _cardRepository.addCard(newCard);
     setState(() {
       _loadCards();
@@ -45,13 +45,16 @@ class _ListPageState extends State<ListPage> {
 
   // カードの変種後の更新
   Future<void> _updateCard(FlashCard flashCard) async {
-    final updateCard = await Navigator.push<FlashCard>(
+    final updateResult = await Navigator.push<EditCardResult>(
       context,
       MaterialPageRoute(builder: (_) => EditPage(card: flashCard)),
     );
 
-    if (updateCard != null) {
-      await _cardRepository.updateCard(updateCard);
+    if (updateResult != null) {
+      await _cardRepository.updateCardWithTags(
+        flashCard: updateResult.card,
+        tagNames: updateResult.tagNames,
+      );
       setState(() {
         _loadCards();
       });
@@ -108,7 +111,7 @@ class _ListPageState extends State<ListPage> {
         label: Text('作成'),
         icon: Icon(Icons.edit),
         onPressed: () async {
-          final newCard = await Navigator.push(
+          final newCard = await Navigator.push<CardDraft>(
             context,
             MaterialPageRoute(builder: (_) => const CreatePage()),
           );


### PR DESCRIPTION
### Motivation
- Allow users to add and edit tags from the card creation and edit screens so tags can be created/linked at the same time as cards.
- Ensure tags are normalized and existing tags are reused instead of creating duplicates when persisting card changes.

### Description
- Added a typed `CardDraft` model and `EditCardResult` wrapper and updated flows so Create/Edit screens return structured data instead of raw lists (`lib/repository/flash_card_repository.dart`, `lib/screens/create_page.dart`, `lib/screens/edit_page.dart`).
- UI changes: added a tag input field (`タグ（, 区切り）`) to the create and edit pages, and prefill edit screen tags by loading existing tags (`lib/screens/create_page.dart`, `lib/screens/edit_page.dart`).
- Repository changes: added `_normalizeTagNames`, `_resolveTags` and `updateCardWithTags` to normalize tag names, reuse or create `Tag` entries, and persist `FlashCard`↔`Tag` links on create/update (`lib/repository/flash_card_repository.dart`).
- List page flow updated to use typed navigation results and to call `addCard` / `updateCardWithTags` to persist tags together with card data (`lib/screens/list_page.dart`).

### Testing
- Attempted to run formatter with `dart format ...` but `dart` was not available in this environment (command failed).
- Attempted to check Flutter with `flutter --version` but `flutter` was not available in this environment (command failed).
- No automated unit or integration tests were executed in this environment; changes were committed locally (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf53d86448328a5224fb5313f1756)